### PR TITLE
changing breathing bar position

### DIFF
--- a/assets/ui/Breathing.ui
+++ b/assets/ui/Breathing.ui
@@ -19,7 +19,7 @@
           "position-horizontal-center": {},
           "position-bottom": {
             "target": "BOTTOM",
-            "offset": 78
+            "offset": 100
           }
         }
       }


### PR DESCRIPTION
when the hunger and thirst modules are active, the breathing bar collides with them. by moving the position a little higher, the issue is solved
![Screenshot from 2021-10-10 17-25-27](https://user-images.githubusercontent.com/11461094/136702541-246cc178-30ee-4f7c-b07d-1e40223f2219.png)
.
